### PR TITLE
Update audio routing documentation and simplify edit_file patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@
 - **One sandboxed tool library** — Shares the same tool library across Agenvoy, Claude Code, Codex, and other agents.
 - **Live command feedback** — Streams throttled command output to the TUI and Web dashboard while preserving the complete final result.
 - **Skill-aware model routing** — Passes matched Skill descriptions into agent selection so the dispatcher can choose models against the actual task contract.
+- **Audio model routing** — Select separate speech-to-text and text-to-speech models from the configured OpenAI or Gemini providers.
 - **Origin-aware confirmations** — Routes approval prompts back to the originating CLI, Web, Telegram, or Discord channel without cross-channel interception.
 - **Extensible integrations** — Connects stdio or HTTP MCP servers, supports OAuth login, and refreshes remote tool catalogs.
 - **Self-hosted execution** — Runs scheduling, memory, and file search on your own machine.
+- **Local-first agent** — Runs on your personal computer, where the agent can safely work with your files, tools, memory, and schedules without moving them to a hosted service.
+- **Private chatbot access** — Telegram and Discord connect back to the local daemon with a token, so users do not need to expose their host or configure inbound networking.
 - **Agent app and MCP server** — Provides both roles from the same binary.
 
 ## What you can do with it
@@ -216,6 +219,12 @@ Open **[web.agenvoy.com](https://web.agenvoy.com)** in your browser to reach the
   <a href="https://youtu.be/n8tHHSCwOjE">▶ Watch the Web Dashboard walkthrough</a>
 </p>
 
+## Chatbot Integrations
+
+Agenvoy currently supports **Telegram and Discord** as its chatbot channels. Both use outbound connections from the daemon, so your host does not need to be exposed to the public internet. Users only need to provide a bot token instead of configuring inbound ports, reverse proxies, or other network plumbing. Additional chatbot platforms will be considered only when they offer a meaningful security improvement.
+
+Voice output is temporarily unavailable in Telegram and Discord; audio model settings remain available for local tool use and future channel support.
+
 ## One-line install
 
 > On MacBook, also run `sudo pmset -c sleep 0` to prevent sleep from interrupting schedules.
@@ -230,12 +239,12 @@ curl -fsSL https://agenvoy.com/scripts/install.sh | bash
 
 A cost-effective model setup to get started:
 
-- Apply for a free **[NVIDIA NIM](https://build.nvidia.com/explore/discover)** API token, then use it for:
-  - `gpt-oss-20b` as the **dispatcher** model
-  - `gpt-oss-120b` as the **fallback** and **summary** model
+- Apply for a free **[NVIDIA NIM](https://build.nvidia.com/explore/discover)** API token for `gpt-oss-20b` as the **dispatcher** model.
 - Use a subscription plan as your **primary** model:
   - OpenAI ChatGPT Plus ($20/mo)
   - SuperGrok ($30/mo)
+
+NVIDIA NIM no longer supports `gpt-oss-120b`, so it is no longer recommended as a fallback or summary model.
 
 ---
 

--- a/doc/README.zh.md
+++ b/doc/README.zh.md
@@ -34,9 +34,11 @@
 - **一套沙箱工具庫** — 在 Agenvoy、Claude Code、Codex 等 Agent 間共用同一套工具庫。
 - **即時執行回饋** — 將節流後的命令輸出串流至 TUI 與 Web 儀表板，同時保留完整的最終結果。
 - **Skill 感知模型路由** — 將符合的 Skill 說明帶入 Agent 選擇，讓 dispatcher 依實際任務契約挑選模型。
-- **來源感知確認流程** — 將核准提示送回原始 CLI、Web、Telegram 或 Discord 頻道，避免跨頻道攔截。
+- **音訊模型路由** — 從已設定的 OpenAI 或 Gemini provider 中，分別選擇語音轉文字與文字轉語音模型。
 - **可擴充整合** — 連接 stdio 或 HTTP MCP server，支援 OAuth 登入並即時刷新遠端工具清單。
 - **自架執行** — 在自己的機器上執行排程、記憶與檔案搜尋。
+- **本機優先的 Agent** — Agent 直接執行在你的個人電腦上，使用本機檔案、工具、記憶與排程，不必將工作移交給託管服務。
+- **私有聊天機器人存取** — Telegram 與 Discord 透過 token 連回本機 daemon，不需要曝光主機或設定入站網路。
 - **Agent 應用 + MCP 伺服器** — 由同一個 binary 同時提供兩種角色。
 
 ## 你可以用它做什麼
@@ -215,6 +217,12 @@ Agenvoy 適合開發者、技術營運，以及需要超越聊天能力的 AI �
   <a href="https://youtu.be/n8tHHSCwOjE">▶ 觀看 Web 儀表板操作影片</a>
 </p>
 
+## 聊天機器人整合
+
+Agenvoy 目前只支援 **Telegram 與 Discord** 作為聊天機器人頻道。兩者都由本機 daemon 主動向外連線，因此不需要將主機暴露到公開網際網路；使用者只要提供 bot token，不必設定入站連接埠、反向代理或其他網路環境。除非後續平台能帶來明確的安全性改善，否則不會擴充其他聊天機器人平台。
+
+語音輸出目前暫時無法在 Telegram 與 Discord 使用；音訊模型設定仍可供本機工具使用，並保留給未來頻道支援。
+
 ## 一鍵安裝
 
 > MacBook 建議額外執行 `sudo pmset -c sleep 0`，避免休眠中斷排程。
@@ -229,12 +237,12 @@ curl -fsSL https://agenvoy.com/scripts/install.sh | bash
 
 一組省錢好上手的模型配置：
 
-- 申請免費的 **[NVIDIA NIM](https://build.nvidia.com/explore/discover)** API token，用於：
-  - `gpt-oss-20b` 作為 **dispatcher** 模型
-  - `gpt-oss-120b` 作為 **fallback** 與 **summary** 模型
+- 申請免費的 **[NVIDIA NIM](https://build.nvidia.com/explore/discover)** API token，使用 `gpt-oss-20b` 作為 **dispatcher** 模型。
 - 用訂閱制當作 **主力** 模型：
   - OpenAI ChatGPT Plus（$20/月）
   - SuperGrok（$30/月）
+
+NVIDIA NIM 已不再支援 `gpt-oss-120b`，因此不再將它列為 fallback 或 summary 模型推薦。
 
 ---
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -46,7 +46,7 @@ graph TB
     Update --> Installer[Official update script]
 ```
 
-The runtime ships 10 model providers, plus the `compat` entry for local or custom OpenAI-compatible endpoints.
+The runtime ships 13 model providers, plus the `compat` entry for local or custom OpenAI-compatible endpoints. Audio routing separately selects speech-to-text and text-to-speech models from the configured OpenAI and Gemini providers; Telegram and Discord voice output is temporarily unavailable.
 
 ## Execution Modes
 

--- a/doc/architecture.zh.md
+++ b/doc/architecture.zh.md
@@ -46,7 +46,7 @@ graph TB
     Update --> Installer[官方更新腳本]
 ```
 
-目前 runtime 內建 10 個模型供應商，另有 `compat` 項目可接本機或自訂的 OpenAI 相容端點。
+目前 runtime 內建 13 個模型供應商，另有 `compat` 項目可接本機或自訂的 OpenAI 相容端點。音訊路由另外從已設定的 OpenAI 與 Gemini provider 選擇語音轉文字與文字轉語音模型；Telegram 與 Discord 目前暫不支援語音輸出。
 
 ## 執行模式
 

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -6,7 +6,7 @@
 
 - Go 1.25.1 or later
 - macOS or another environment supporting Go, SQLite, and the `go-pkg` sandbox dependencies
-- At least one configured model-provider credential; Telegram, Discord, voice, and KuraDB need their respective credentials. Image generation is temporarily unavailable.
+- At least one configured model-provider credential; Telegram and Discord require their respective bot tokens. Speech-to-text and text-to-speech require a selected audio model and its provider credential. KuraDB needs its respective credential. Image generation is temporarily unavailable.
 
 ## Installation
 
@@ -58,10 +58,18 @@ Agenvoy stores runtime data in `~/.config/agenvoy/` and keeps credentials in the
 
 | Keychain entry | Used by |
 |---|---|
-| `OPENAI_API_KEY` | OpenAI and KuraDB |
+| `OPENAI_API_KEY` | OpenAI, OpenAI audio models, and KuraDB |
 | `CLAUDE_API_KEY`, `GROK_API_KEY`, `DEEPSEEK_API_KEY` | The matching model providers |
 | `TELEGRAM_TOKEN`, `DISCORD_TOKEN` | Chat-bot integrations |
-| `GEMINI_API_KEY` | Voice replies and `transcribe_media`; without it the tool is not registered |
+| `GEMINI_API_KEY` | Gemini audio models and voice features |
+
+### Audio model routing
+
+Speech-to-text and text-to-speech models are configured separately from the session, dispatcher, summary, and image settings. In the TUI, use `/model stt` or `/model tts`; choose `off` to disable the corresponding capability. The available models are loaded from configured OpenAI and Gemini providers. Telegram and Discord voice output is temporarily unavailable, but the local `generate_audio` tool and audio model settings remain available for local use and future channel support.
+
+### Chatbot integrations
+
+Agenvoy currently supports Telegram and Discord. Both integrations use outbound connections from the local daemon, so the host does not need to expose an inbound port or public endpoint. Configuration requires only the corresponding bot token. Other chatbot platforms are out of scope unless they provide a meaningful security improvement.
 
 ### Runtime configuration
 
@@ -389,7 +397,6 @@ The daemon binds to `127.0.0.1` only. Endpoints marked **local** additionally re
 | | `reasoning_guide` | Full reasoning rules by `topic` |
 | Support | `calculate` | Arithmetic, unit and currency conversion |
 | | `store_secret` | Masked prompt, stored in the keychain |
-| Conditional | `transcribe_media` | Audio and video to text — needs `GEMINI_API_KEY` |
 | Conditional | `generate_image` | Text to image, saved to disk — excluded while the image generator is off |
 | | `list_chatbot`, `send_to_chatbot` | Cross-channel push — needs Telegram or Discord enabled |
 

--- a/doc/doc.zh.md
+++ b/doc/doc.zh.md
@@ -6,7 +6,7 @@
 
 - Go 1.25.1 或更新版本
 - macOS 或支援 Go、SQLite 與 `go-pkg/sandbox` 相依套件的環境
-- 至少一組模型供應商憑證；透過 TUI 設定 API key 或 OAuth
+- 至少一組模型供應商憑證；Telegram 與 Discord 需要各自的 bot token，語音轉文字與文字轉語音需要選定音訊模型及其 provider 憑證，KuraDB 需要各自的憑證
 
 ## 安裝
 
@@ -58,10 +58,18 @@ Agenvoy 使用 `~/.config/agenvoy/` 保存執行期資料，並將憑證存放�
 
 | Keychain 項目                                        | 用途                                                  |
 | ---------------------------------------------------- | ----------------------------------------------------- |
-| `OPENAI_API_KEY`                                     | OpenAI 與 KuraDB                                      |
+| `OPENAI_API_KEY`                                     | OpenAI、OpenAI 音訊模型與 KuraDB                  |
 | `CLAUDE_API_KEY`、`GROK_API_KEY`、`DEEPSEEK_API_KEY` | 對應模型供應商                                        |
 | `TELEGRAM_TOKEN`、`DISCORD_TOKEN`                    | 聊天機器人整合                                        |
-| `GEMINI_API_KEY`                                     | 語音回覆與 `transcribe_media`；未設定時該工具不會註冊 |
+| `GEMINI_API_KEY`                                     | Gemini 音訊模型與語音功能                         |
+
+### 音訊模型路由
+
+語音轉文字與文字轉語音模型，分別獨立於 session、dispatcher、summary 與圖片設定。在 TUI 中使用 `/model stt` 或 `/model tts` 設定；選擇 `off` 可停用對應功能。可用模型會從已設定的 OpenAI 與 Gemini provider 載入。Telegram 與 Discord 的語音輸出目前暫時無法使用，但本機 `generate_audio` 工具與音訊模型設定仍可供本機使用，並保留給未來頻道支援。
+
+
+Agenvoy 目前支援 Telegram 與 Discord。兩者都由本機 daemon 主動向外連線，因此主機不需要開放入站連接埠或公開端點；設定時只需要提供對應的 bot token。其他聊天機器人平台除非能帶來明確的安全性改善，否則不在目前規劃內。
+
 
 ### Runtime 設定
 
@@ -93,7 +101,11 @@ Agenvoy 使用 `~/.config/agenvoy/` 保存執行期資料，並將憑證存放�
 
 ### TUI 執行模式
 
-目前 runtime 內建 10 個模型供應商，另有 `compat` 項目可接本機或自訂的 OpenAI 相容端點（Ollama、LM Studio、自架 gateway）。
+目前 runtime 內建 13 個模型供應商，另有 `compat` 項目可接本機或自訂的 OpenAI 相容端點（Ollama、LM Studio、自架 gateway）。
+
+### 音訊模型路由
+
+語音轉文字與文字轉語音模型，會與 session、dispatcher、summary 及圖片設定分開配置。在 TUI 中使用 `/model stt` 或 `/model tts`；選擇 `off` 可停用對應能力。可用模型來自已設定的 OpenAI 與 Gemini provider。Telegram 與 Discord 的語音輸出目前暫時無法使用，但本機 `generate_audio` 工具與音訊模型設定仍可供本機使用，並保留給未來頻道支援。
 
 當輸入區為空時，按下 `Shift+F` 可切換 fast mode。啟用時，標題列會顯示 `[fast]`。Fast mode 只存在於目前行程，不會保存至 `config.json`；它會透過 `go-llm-router` v0.5.1 傳遞 `provider.ModeFast`，讓支援的 provider backend 要求更快速的服務層級。關閉 fast mode 時則使用預設模式。
 
@@ -169,7 +181,7 @@ agen
 
 | 指令                            | 用途                                                                                  |
 | ------------------------------- | ------------------------------------------------------------------------------------- |
-| `/model`                        | 新增／移除 provider，挑選 session／dispatcher／summary 模型，設定圖片生成來源         |
+| `/model`                        | 新增／移除 provider，挑選 session／dispatcher／summary 模型，設定圖片生成與 STT／TTS 模型         |
 | `/mcp`                          | 列出 MCP server；新增、登入、重連、查看工具、設定單一工具權限、移除                   |
 | `/switch` `/new`                | 切換 session 或建立新的（名稱會檢查重複）                                             |
 | `/bot`                          | 重新命名當前 session 或編輯 persona                                                   |
@@ -267,7 +279,7 @@ Daemon 只綁定 `127.0.0.1`。標示 **local** 的 endpoint 另外要求請求�
 | `GET`           | `/v1/models`                    | 列出已註冊模型（OpenAI `{data:[...]}` 格式,含 `auto`） |
 | `GET`           | `/v1/models/*id`                | 讀取單一已註冊模型                                   |
 | `POST` `DELETE` | `/v1/models` `/v1/models/*name` | **local** — 新增／移除模型                           |
-| `GET` `POST`    | `/v1/model`                     | **local** — 模型路由：`dispatcher`／`summary`／`image`，讀取時另附 `image_options`。三個欄位放的東西不同類：`dispatcher` 與 `summary` 填已註冊的模型名（`prefix@model`），`image` 填的是 provider endpoint（`openai`／`codex`／`grok`／`grok-oauth`／`gemini`）——因為各 provider 的圖片模型寫死在 `go-llm-router` 內，選的是來源不是模型；`image_options` 只列出當前有憑證的 provider。`POST` 為部分更新：未帶（或 `null`）的欄位不動，`""` 清除，`image` 另接受 `off` 作為 `""` 的別名。模型未註冊、provider 不存在、或該 provider 沒有憑證一律拒絕且整批不寫。兩個動詞回傳同一種物件 |
+| `GET` `POST`    | `/v1/model/audio`               | **local** — 讀取或設定語音轉文字（`stt`）與文字轉語音（`tts`）模型；可用選項來自已設定的 OpenAI 與 Gemini provider |
 
 **Session**
 
@@ -405,7 +417,6 @@ Daemon 只綁定 `127.0.0.1`。標示 **local** 的 endpoint 另外要求請求�
 |            | `reasoning_guide`                 | 依 `topic` 取得完整推理規則                                                            |
 | 基礎支援   | `calculate`                       | 算術、單位與匯率換算                                                                   |
 |            | `store_secret`                    | 遮蔽輸入並存入 keychain                                                                |
-| 條件註冊   | `transcribe_media`                | 音訊／影片轉文字——需 `GEMINI_API_KEY`                                                  |
 | 條件註冊   | `generate_image`                  | 文字生成圖片並存檔——image generator 為 off 時排除                                      |
 |            | `list_chatbot`、`send_to_chatbot` | 跨頻道推送——需啟用 Telegram 或 Discord                                                 |
 

--- a/internal/agents/exec/toolCall.go
+++ b/internal/agents/exec/toolCall.go
@@ -247,22 +247,21 @@ func truncateWriteArgs(argsJSON string) string {
 		return argsJSON
 	}
 
-	dics := []map[string]any{m}
+	kept := map[string]any{}
+	for key, value := range m {
+		if key == "content" || key == "targets" {
+			continue
+		}
+		kept[key] = value
+	}
 	if targets, ok := m["targets"].([]any); ok {
-		for _, t := range targets {
-			if tm, ok := t.(map[string]any); ok {
-				dics = append(dics, tm)
-			}
-		}
+		kept["edits"] = len(targets)
 	}
-	for _, dic := range dics {
-		for _, field := range []string{"content", "new_string"} {
-			if _, ok := dic[field]; ok {
-				dic[field] = toolTypes.Elided
-			}
-		}
+	if content, ok := m["content"].(string); ok {
+		kept["wrote_bytes"] = len(content)
 	}
-	out, err := json.Marshal(m)
+
+	out, err := json.Marshal(kept)
 	if err != nil {
 		return argsJSON
 	}

--- a/internal/tools/file/editFile.go
+++ b/internal/tools/file/editFile.go
@@ -40,32 +40,25 @@ Skill files → edit_skill; tool definitions → edit_tool; past versions → fi
 				},
 				"targets": map[string]any{
 					"type":        "array",
-					"description": "mode=patch: the edits to that file — read_files it first so every anchor matches the current bytes, minus the \"12\\t\" line-number prefix that read_files adds. Each item replaces ({old_string, new_string[, replace_all][, row]}) or inserts ({insert_string, row}), never both. Items carrying row apply highest-row first so line numbers stay valid against the original; the rest then apply in listed order, so sequence overlapping old_string items yourself.",
+					"description": "mode=patch: the edits to that file — read_files it first so every old_string matches the current bytes, minus the \"12\\t\" line-number prefix that read_files adds. Each item is {old_string, new_string}: new_string takes the place of old_string, empty deletes it, and to add lines you repeat old_string at the start of new_string. Items apply in the order listed, so sequence overlapping edits yourself.",
 					"items": map[string]any{
 						"type": "object",
 						"properties": map[string]any{
 							"old_string": map[string]any{
 								"type":        "string",
-								"description": "Exact text to replace, indentation included — copy it from the file bytes, never with the line-number prefix. Must be unique unless replace_all or row disambiguates. Omit with insert_string.",
+								"description": "Exact text to replace, indentation included — copy it from the file bytes, never with the line-number prefix. Must match once unless replace_all is set; extend it with surrounding lines until it does.",
 							},
 							"new_string": map[string]any{
 								"type":        "string",
-								"description": "Replacement text; empty deletes old_string. With row, deletes only that line's occurrence. Ignored when insert_string is set.",
+								"description": "What old_string becomes. Empty deletes it. To insert, start with old_string unchanged and append the new lines after it.",
 							},
 							"replace_all": map[string]any{
 								"type":        "boolean",
 								"description": "Replace every occurrence instead of the single unique one — for renames.",
 								"default":     false,
 							},
-							"insert_string": map[string]any{
-								"type":        "string",
-								"description": "New line(s) added as they are — nothing is replaced, the surrounding lines shift down. Say where with row, taken from a read_files of the current file; cannot combine with old_string.",
-							},
-							"row": map[string]any{
-								"type":        "integer",
-								"description": "1-based line number as read_files prints it. With old_string: which occurrence to edit. With insert_string: required — the line the new text goes in front of, so read_files the file first; any in-range row is accepted as-is.",
-							},
 						},
+						"required": []string{"old_string", "new_string"},
 					},
 				},
 				"version": map[string]any{

--- a/internal/tools/file/patchFile.go
+++ b/internal/tools/file/patchFile.go
@@ -54,14 +54,6 @@ func patchFileTargets(ctx context.Context, e *toolTypes.Executor, path0 string, 
 	for i := range order {
 		order[i] = i
 	}
-	sort.SliceStable(order, func(a, b int) bool {
-		ra, rb := targets[order[a]].Row, targets[order[b]].Row
-		if ra > 0 && rb > 0 {
-			return ra > rb
-		}
-		return ra > 0 && rb == 0
-	})
-
 	before := content
 	var skipped []int
 	for _, i := range order {
@@ -72,9 +64,6 @@ func patchFileTargets(ctx context.Context, e *toolTypes.Executor, path0 string, 
 		if err != nil {
 			if conflict := batchConflict(before, content, absPath, targets, order, i); conflict != "" {
 				return "", fmt.Errorf("targets[%d]: %s", i, conflict)
-			}
-			if content != before && strings.Contains(err.Error(), "row") {
-				return "", fmt.Errorf("targets[%d]: %w — every row in this call counts against the file as it is on disk, since the targets carrying row are applied from the highest row down; nothing was written, so re-read the file and take the number from its output", i, err)
 			}
 			return "", fmt.Errorf("targets[%d]: %w", i, err)
 		}
@@ -112,7 +101,7 @@ func patchFileTargets(ctx context.Context, e *toolTypes.Executor, path0 string, 
 func rejectElided(content string, targets []patchTarget) error {
 	values := []string{content}
 	for _, one := range targets {
-		values = append(values, one.OldString, one.NewString, one.InsertString)
+		values = append(values, one.OldString, one.NewString)
 	}
 	if slices.ContainsFunc(values, toolTypes.IsElided) {
 		return fmt.Errorf("%s is a history placeholder, not file content — the earlier write already landed on disk; read_files the file and copy the real text", toolTypes.Elided)
@@ -121,57 +110,36 @@ func rejectElided(content string, targets []patchTarget) error {
 }
 
 type patchTarget struct {
-	OldString    string `json:"old_string"`
-	NewString    string `json:"new_string"`
-	ReplaceAll   bool   `json:"replace_all"`
-	InsertString string `json:"insert_string"`
-	Row          int    `json:"row"`
+	OldString  string `json:"old_string"`
+	NewString  string `json:"new_string"`
+	ReplaceAll bool   `json:"replace_all"`
 }
 
 func applyTarget(content string, target patchTarget, absPath string) (string, error) {
-	switch {
-	case target.InsertString != "":
-		if target.OldString != "" {
-			return "", fmt.Errorf("insert_string cannot be combined with old_string")
-		}
-		if target.NewString != "" {
-			return "", fmt.Errorf("insert_string cannot be combined with new_string; to replace text send {old_string, new_string}, to add lines send insert_string alone")
-		}
-		if target.Row <= 0 {
-			return "", fmt.Errorf("row is required when insert_string is set; re-read the file and take the number from its output")
-		}
-		return insertAtRow(content, target.InsertString, target.Row)
-
-	case target.OldString != "":
-		old := target.OldString
-		new := target.NewString
-		if old == new {
-			return content, nil
-		}
-		if !strings.Contains(content, old) {
-			return "", anchorNotFound(content, old, absPath)
-		}
-
-		search := old
-		if new == "" && !strings.HasSuffix(old, "\n") && strings.Contains(content, old+"\n") {
-			search = old + "\n"
-		}
-
-		switch {
-		case target.ReplaceAll:
-			return strings.ReplaceAll(content, search, new), nil
-		case target.Row > 0:
-			return replaceAtRow(content, search, new, target.Row)
-		default:
-			if rows := rowsOf(content, search); len(rows) > 1 {
-				return "", fmt.Errorf("%s occurs on rows %v of %s; set row to one of them or replace_all", old, rows, absPath)
-			}
-			return strings.Replace(content, search, new, 1), nil
-		}
-
-	default:
-		return "", fmt.Errorf("either old_string or insert_string is required")
+	old := target.OldString
+	new := target.NewString
+	if old == "" {
+		return "", fmt.Errorf("old_string is required")
 	}
+	if old == new {
+		return content, nil
+	}
+	if !strings.Contains(content, old) {
+		return "", anchorNotFound(content, old, absPath)
+	}
+
+	search := old
+	if new == "" && !strings.HasSuffix(old, "\n") && strings.Contains(content, old+"\n") {
+		search = old + "\n"
+	}
+
+	if target.ReplaceAll {
+		return strings.ReplaceAll(content, search, new), nil
+	}
+	if rows := rowsOf(content, search); len(rows) > 1 {
+		return "", fmt.Errorf("%s occurs on rows %v of %s; extend old_string until it matches once, or set replace_all", old, rows, absPath)
+	}
+	return strings.Replace(content, search, new, 1), nil
 }
 
 func batchConflict(original, current, absPath string, targets []patchTarget, order []int, at int) string {
@@ -186,9 +154,6 @@ func batchConflict(original, current, absPath string, targets []patchTarget, ord
 			break
 		}
 		other := targets[j].OldString
-		if other == "" {
-			other = targets[j].InsertString
-		}
 		if other != "" && (strings.Contains(old, other) || strings.Contains(other, old)) {
 			by = append(by, fmt.Sprintf("targets[%d]", j))
 		}
@@ -229,23 +194,6 @@ func anchorNotFound(content, old, absPath string) error {
 	return fmt.Errorf("%q is not found in %s, but %s — copy the anchor from those exact bytes, whitespace included", old, absPath, strings.Join(near, "; "))
 }
 
-func replaceAtRow(content, search, new string, row int) (string, error) {
-	idx := 0
-	for {
-		i := strings.Index(content[idx:], search)
-		if i < 0 {
-			break
-		}
-		pos := idx + i
-		line := strings.Count(content[:pos], "\n") + 1
-		if line == row {
-			return content[:pos] + new + content[pos+len(search):], nil
-		}
-		idx = pos + 1
-	}
-	return "", fmt.Errorf("no match for %q at row %d; it is on rows %v", search, row, rowsOf(content, search))
-}
-
 func rowsOf(content, search string) []int {
 	var rows []int
 	for idx := 0; ; {
@@ -257,32 +205,4 @@ func rowsOf(content, search string) []int {
 		rows = append(rows, strings.Count(content[:pos], "\n")+1)
 		idx = pos + 1
 	}
-}
-
-func insertAtRow(content, insert string, row int) (string, error) {
-	lines := strings.Split(content, "\n")
-	lineCount := len(lines)
-	if lineCount > 0 && lines[lineCount-1] == "" {
-		lineCount--
-	}
-	if row < 1 || row > lineCount+1 {
-		return "", fmt.Errorf("row %d out of range (file has %d lines)", row, lineCount)
-	}
-
-	insert = strings.TrimSuffix(insert, "\n")
-	insert = strings.TrimSuffix(insert, "\r")
-
-	idx := row - 1
-	added := strings.Split(insert, "\n")
-	after := idx+len(added) <= len(lines) && slices.Equal(lines[idx:idx+len(added)], added)
-	before := idx-len(added) >= 0 && slices.Equal(lines[idx-len(added):idx], added)
-	if after || before {
-		return content, nil
-	}
-
-	out := make([]string, 0, len(lines)+len(added))
-	out = append(out, lines[:idx]...)
-	out = append(out, added...)
-	out = append(out, lines[idx:]...)
-	return strings.Join(out, "\n"), nil
 }


### PR DESCRIPTION
This hotfix restores the original `edit_file` patch format: a target is once again just `old_string` and `new_string`, the shape the tool shipped with in [7121a1a1]. The `insert_string` and `row` variants added in [e1f850a0] gave one edit several possible spellings, and runs stalled retrying combinations the tool rejected. Anchored replacement is what keeps file editing predictable.
